### PR TITLE
Made it possible to use the plugin like `.use(markdown)`

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -9,7 +9,14 @@ var marked = require('marked');
  * Expose `plugin`.
  */
 
-module.exports = plugin;
+module.exports = function(){
+  var argArr = [].slice.call(arguments);
+  if ( arguments.length === 3){ // If this plugin was used like `.use(markdown)`
+    plugin().apply(null, argArr);
+  } else { // if this plugin was used like `.use(markdown())`
+    return plugin.apply(null, argArr);
+  }
+};
 
 /**
  * Metalsmith plugin to convert markdown files.

--- a/test/index.js
+++ b/test/index.js
@@ -29,4 +29,15 @@ describe('metalsmith-markdown', function(){
         done();
       });
   });
+
+  it('should work without any options', function(done){
+    Metalsmith('test/fixtures/direct')
+      .use(markdown)
+      .build(function(err, files){
+        if (err) return done(err);
+        equal('test/fixtures/direct/expected', 'test/fixtures/direct/build');
+        done();
+      });
+  });
+
 });


### PR DESCRIPTION
In the [README](https://github.com/segmentio/metalsmith) of metalsmith you use the markdown plugin without bracket like this:

``` js
 Metalsmith(__dirname)
    .use(markdown);
    .build([...])
```

But this isn't implemented right now. 

This PR will use `.apply` to delegate the function call correctly. 

Basically it is just doing this:

``` js
if ( arguments.length === 3){
  plugin().apply(null, [].slice.call(arguments));
}
```
