### PR TITLE
Add Option to Know Which Files are Processed As Markdown

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -7,9 +7,16 @@
 
     $ npm install metalsmith-markdown
 
+## Options
+
+  All [Marked](https://github.com/chjj/marked) options are supported.
+
+  There is an additional optional option `markerAttribute` which specifies a page data attribute to set on all markdown files. This
+  allows for templates to identify content that came from markdown vs html or some other templating language.
+
 ## CLI Usage
 
-  Install via npm and then add the `metalsmith-markdown` key to your `metalsmith.json` plugins with any [Marked](https://github.com/chjj/marked) options you want, like so:
+  Install via npm and then add the `metalsmith-markdown` key to your `metalsmith.json` plugins with any options you want, like so:
 
 ```json
 {
@@ -17,7 +24,8 @@
     "metalsmith-markdown": {
       "smartypants": true,
       "gfm": true,
-      "tables": true
+      "tables": true,
+      "markerAttribute": "wasMarkdown"
     }
   }
 }
@@ -33,7 +41,8 @@ var markdown = require('metalsmith-markdown');
 metalsmith.use(markdown({
   smartypants: true,
   gfm: true,
-  tables: true
+  tables: true,
+  markerAttribute: "wasMarkdown"
 }));
 ```
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -40,6 +40,10 @@ function plugin(options){
         data[key] = marked(data[key], options);
       });
 
+      if (options.markerAttribute) {
+          data[options.markerAttribute] = true;
+      }
+
       delete files[file];
       files[html] = data;
     });

--- a/test/index.js
+++ b/test/index.js
@@ -29,4 +29,24 @@ describe('metalsmith-markdown', function(){
         done();
       });
   });
+
+  it('should set the marker attribute if provided', function(done){
+    var sawAttribute = false;
+
+    Metalsmith('test/fixtures/basic')
+      .use(markdown({
+        markerAttribute: 'wasMarkdown'
+      }))
+      .use(function(files, metalsmith, done) {
+        Object.keys(files).forEach(function(file){
+          sawAttribute = files[file].wasMarkdown === true;
+        });
+        done();
+      })
+      .build(function(err){
+        if (err) return done(err);
+        assert(sawAttribute, 'Attribute was not set.');
+        done();
+      });
+  });
 });


### PR DESCRIPTION
This allows users of the plugin to know which files started as markdown and which files didn't.

My usecase for this is in a template that applies a special class to content that started as markdown to give it some basic styling that markdown expects to be in place. This same styling I don't want to be applied to cotents that started as html as those pages are generally more advanced and don't need to basic markdown styling.
