### PR TITLE
Show usage with syntax highlighting

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -29,11 +29,13 @@
 
 ```js
 var markdown = require('metalsmith-markdown');
+var highlighter = require('highlighter');
 
 metalsmith.use(markdown({
   smartypants: true,
   gfm: true,
-  tables: true
+  tables: true,
+  highlight: highlighter()
 }));
 ```
 


### PR DESCRIPTION
I recently published a syntax highlighting module (does the repetitive try/catch highlight.js loop for you) that also includes syntax highlighting inside diffs (like Github recently supported). Aside from being simple to use and include, I think the readme can benefit showing how to add syntax highlighting to markdown files, regardless of whether it's this module or the raw highlight.js function.

Module in action with diffs: http://blakeembrey.com/articles/2014/09/building-a-blog-with-metalsmith/
