### PR TITLE
Expose instance of marked.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -37,6 +37,28 @@ metalsmith.use(markdown({
 }));
 ```
 
+  You can also use metalsmith-markdown's instance of marked, for example if you would like to supply a custom renderer.
+
+```js
+var markdown = require('metalsmith-markdown');
+var renderer = new markdown.marked.Renderer();
+
+renderer.heading = function (text, level) {
+  var escapedText = text.toLowerCase().replace(/[^\w]+/g, '-');
+
+  return '<h' + level + '><a name="' +
+                escapedText +
+                 '" class="anchor" href="#' +
+                 escapedText +
+                 '"><span class="header-link"></span></a>' +
+                  text + '</h' + level + '>';
+},
+
+metalsmith.use(markdown({
+  renderer: renderer
+}));
+```
+
 ## License
 
   MIT

--- a/lib/index.js
+++ b/lib/index.js
@@ -12,6 +12,12 @@ var marked = require('marked');
 module.exports = plugin;
 
 /**
+ * Expose metalsmith-markdown's instance of marked
+ */
+
+module.exports.marked = marked;
+
+/**
  * Metalsmith plugin to convert markdown files.
  *
  * @param {Object} options (optional)


### PR DESCRIPTION
Convenience so that you don't have to install/require marked yourself if you're using metalsmith-markdown.
