### PR TITLE
Robustness for missing keys

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -37,7 +37,9 @@ function plugin(options){
       var str = marked(data.contents.toString(), options);
       data.contents = new Buffer(str);
       keys.forEach(function(key) {
-        data[key] = marked(data[key], options);
+        if (data[key]) {
+          data[key] = marked(data[key], options);
+        }
       });
 
       delete files[file];


### PR DESCRIPTION
The plugin crashes if some files don't have a key that is specified in options.keys. This fix makes it skip non-existing keys in a single file.
