### PR TITLE
Match of extension name of the markdown files with precise regex.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -54,5 +54,5 @@ function plugin(options){
  */
 
 function markdown(file){
-  return /\.md|\.markdown/.test(extname(file));
+  return /\.md$|\.markdown$/.test(extname(file));
 }


### PR DESCRIPTION
The current code also considers files like `foo.md~` valid markdown files. The patch prevents accidental matches of these files.
