### PR TITLE
Pass metadata to markdown

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -37,6 +37,27 @@ metalsmith.use(markdown({
 }));
 ```
 
+## The `keys` option
+
+If you'd like to use markdown in your frontmatter, just specify which keys
+you'd like to convert.
+
+```js
+metalsmith.use(markdown({
+  keys: ['text']
+}));
+```
+
+Now nothing stops you to use markdown in your frontmatter.
+
+```
+---
+custom: _a_
+---
+
+Body
+```
+
 ## License
 
   MIT

--- a/Readme.md
+++ b/Readme.md
@@ -58,6 +58,32 @@ custom: _a_
 Body
 ```
 
+## The `useMetadata` option
+
+If you'd like to set file specific markdown options, you can achieve that
+with the `useMetadata` option set to `true`.
+
+```js
+metalsmith.use(markdown({
+  useMetadata: true
+}));
+```
+
+Now you can pass options to the markdown converter by specifying them
+in your frontmatter.
+
+```
+---
+gfm: false
+---
+
+~~Mistaken text.~~
+```
+
+Even options in your global metalsmith metadata will be passed to the
+markdown converter. This way you can specify specific markdown options
+for a subtree.
+
 ## License
 
   MIT

--- a/lib/index.js
+++ b/lib/index.js
@@ -23,8 +23,29 @@ function plugin(options){
   options = options || {};
   var keys = options.keys || [];
 
+  var mix = function(obj1, obj2) {
+    var newObj = {};
+    var key;
+    for (key in obj1) {
+      if (obj1.hasOwnProperty(key)) {
+        newObj[key] = obj1[key];
+      }
+    }
+    for (key in obj2) {
+      if (obj2.hasOwnProperty(key)) {
+        newObj[key] = obj2[key];
+      }
+    }
+    return newObj;
+  };
+
   return function(files, metalsmith, done){
     setImmediate(done);
+
+    if (options.useMetadata) {
+      options = mix(options, metalsmith.data);
+    }
+
     Object.keys(files).forEach(function(file){
       debug('checking file: %s', file);
       if (!markdown(file)) return;
@@ -34,10 +55,11 @@ function plugin(options){
       if ('.' != dir) html = dir + '/' + html;
 
       debug('converting file: %s', file);
-      var str = marked(data.contents.toString(), options);
+      markedOptions = (options.useMetadata ? mix(options, data) : options);
+      var str = marked(data.contents.toString(), markedOptions);
       data.contents = new Buffer(str);
       keys.forEach(function(key) {
-        data[key] = marked(data[key], options);
+        data[key] = marked(data[key], markedOptions);
       });
 
       delete files[file];

--- a/test/fixtures/metadata/build/index.html
+++ b/test/fixtures/metadata/build/index.html
@@ -1,0 +1,1 @@
+<p>~~Mistaken text.~~</p>

--- a/test/fixtures/metadata/expected/index.html
+++ b/test/fixtures/metadata/expected/index.html
@@ -1,0 +1,1 @@
+<p>~~Mistaken text.~~</p>

--- a/test/fixtures/metadata/src/index.md
+++ b/test/fixtures/metadata/src/index.md
@@ -1,0 +1,4 @@
+---
+gfm: false
+---
+~~Mistaken text.~~

--- a/test/index.js
+++ b/test/index.js
@@ -29,4 +29,17 @@ describe('metalsmith-markdown', function(){
         done();
       });
   });
+
+  it('should allow a "useMetadata" option', function(done){
+    Metalsmith('test/fixtures/metadata')
+      .use(markdown({
+        useMetadata: true,
+        smartypants: true
+      }))
+      .build(function(err, files){
+        if (err) return done(err);
+        equal('test/fixtures/metadata/expected', 'test/fixtures/metadata/build');
+        done();
+      });
+  });
 });


### PR DESCRIPTION
I need to pass some data from the Metalsmith workflow down to the Marked compiler. In order to achieve this in the same way `metalsmith-jade` already does, this change introduces a `useMetadata` option. If you set it to `true`, every option you set on this plugin is passed down to the compiler too.

The pr additionally adds a brief description for the `keys` option, which is currently missing.
