### PR TITLE
Use the right separator in file path.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -3,6 +3,7 @@ var basename = require('path').basename;
 var debug = require('debug')('metalsmith-markdown');
 var dirname = require('path').dirname;
 var extname = require('path').extname;
+var join = require('path').join;
 var marked = require('marked');
 
 /**
@@ -31,7 +32,7 @@ function plugin(options){
       var data = files[file];
       var dir = dirname(file);
       var html = basename(file, extname(file)) + '.html';
-      if ('.' != dir) html = dir.replace(/\\/g, '/') + '/' + html;
+      if ('.' != dir) html = join(dir, html);
 
       debug('converting file: %s', file);
       var str = marked(data.contents.toString(), options);

--- a/lib/index.js
+++ b/lib/index.js
@@ -31,7 +31,7 @@ function plugin(options){
       var data = files[file];
       var dir = dirname(file);
       var html = basename(file, extname(file)) + '.html';
-      if ('.' != dir) html = dir + '/' + html;
+      if ('.' != dir) html = dir.replace(/\\/g, '/') + '/' + html;
 
       debug('converting file: %s', file);
       var str = marked(data.contents.toString(), options);


### PR DESCRIPTION
On Windows the directory path can include backslash () and thats what
path.dirname returns. The file path is then added with a slash (/).

This will result in paths like "**services\marketing/email.html**"

This commit replace backslash with slash in the directory path when its
concatenated with the filename.
