### PR TITLE
Change to using kramed

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -9,7 +9,7 @@
 
 ## CLI Usage
 
-  Install via npm and then add the `metalsmith-markdown` key to your `metalsmith.json` plugins with any [Marked](https://github.com/chjj/marked) options you want, like so:
+  Install via npm and then add the `metalsmith-markdown` key to your `metalsmith.json` plugins with any [kramed](https://github.com/GitbookIO/kramed) options you want, like so:
 
 ```json
 {

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,7 +3,7 @@ var basename = require('path').basename;
 var debug = require('debug')('metalsmith-markdown');
 var dirname = require('path').dirname;
 var extname = require('path').extname;
-var marked = require('marked');
+var kramed = require('kramed');
 
 /**
  * Expose `plugin`.
@@ -34,10 +34,10 @@ function plugin(options){
       if ('.' != dir) html = dir + '/' + html;
 
       debug('converting file: %s', file);
-      var str = marked(data.contents.toString(), options);
+      var str = kramed(data.contents.toString(), options);
       data.contents = new Buffer(str);
       keys.forEach(function(key) {
-        data[key] = marked(data[key], options);
+        data[key] = kramed(data[key], options);
       });
 
       delete files[file];

--- a/package.json
+++ b/package.json
@@ -6,12 +6,15 @@
   "license": "MIT",
   "main": "lib/index.js",
   "dependencies": {
-    "marked": "~0.3.1",
+    "kramed": "~0.5.5",
     "debug": "~0.7.4"
   },
   "devDependencies": {
     "mocha": "1.x",
     "metalsmith": "0.x",
     "assert-dir-equal": "0.x"
+  },
+  "scripts": {
+    "test": "mocha test/index.js"
   }
 }


### PR DESCRIPTION
GitBook have a similar project to marked called [kramed](https://github.com/GitbookIO/kramed). It supports the same basic options as well as much of the newer kramdown standard. This PR changes metalsmith-markdown plugin to using kramed.

I've also added an npm script `npm test` to run the test suite.
