### PR TITLE
Add base url

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -89,6 +89,16 @@ metalsmith.use(markdown({
   xhtml: false
 }));
 ```
+## baseUrl options
+
+"addBaseUrl" and "basePrefix" may be used to control marked's baseUrl option. "addBaseUrl" sets baseUrl to the path of the current file. "basePrefix" adds a prefix if addBaseUrl is also set:
+
+```js
+    {
+    "addBaseUrl": true,
+    "basePrefix": "https://example.com/blog"
+    }
+```
 
 ## History
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -35,6 +35,11 @@ var plugin = function(options) {
       var dir = dirname(file);
       var html = basename(file, extname(file)) + '.html';
       if ('.' != dir) html = join(dir, html);
+      if (options.addBaseUrl){
+        const prefix = options.basePrefix || ""
+        const dirPath = ('.' != dir) ? dir : "";
+        options.baseUrl  = prefix + "/" + dirPath + "/";
+      }
 
       debug('converting file: %s', file);
       var str = marked(data.contents.toString(), options);


### PR DESCRIPTION
Add two options: "addBaseUrl" and "basePrefix". They may be used to control marked's baseUrl option. "addBaseUrl" sets baseUrl to the path of the current file. "basePrefix" adds a prefix if addBaseUrl is also set:

```js
    {
    "addBaseUrl": true,
    "basePrefix": "https://example.com/blog"
    }
```

Not extensively tested, but seems to work for me.