### PR TITLE
chore: update marked@2.1.0 to marked@4.0.12

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,6 @@
 const { basename, dirname, extname, join } = require('path')
 const debug = require('debug')('@metalsmith/markdown')
-// marked main is set to 'src/marked' which contains unsupported syntax for Node 8-
-const marked = require('marked/lib/marked')
+const { marked } = require('marked')
 
 /**
  * Check if a `file` is markdown

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "debug": "^4.3.3",
-        "marked": "^2.1.0"
+        "marked": "^4.0.12"
       },
       "devDependencies": {
         "assert-dir-equal": "^1.1.0",
@@ -4441,14 +4441,14 @@
       }
     },
     "node_modules/marked": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-2.1.0.tgz",
-      "integrity": "sha512-KSdOTs1I/+hrQrFB+e7O/r+AorwdD4XzAi9caoRrbbkRLUS6txr1MZCZQhimm1N5Pg7A/WazC9VrYgqnwGiXMg==",
+      "version": "4.0.12",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.12.tgz",
+      "integrity": "sha512-hgibXWrEDNBWgGiK18j/4lkS6ihTe9sxtV4Q1OQppb/0zzyPSzoFANBa5MfsG/zgsWklmNnhm0XACZOH/0HBiQ==",
       "bin": {
-        "marked": "bin/marked"
+        "marked": "bin/marked.js"
       },
       "engines": {
-        "node": ">= 8.16.2"
+        "node": ">= 12"
       }
     },
     "node_modules/merge-stream": {
@@ -10996,9 +10996,9 @@
       }
     },
     "marked": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-2.1.0.tgz",
-      "integrity": "sha512-KSdOTs1I/+hrQrFB+e7O/r+AorwdD4XzAi9caoRrbbkRLUS6txr1MZCZQhimm1N5Pg7A/WazC9VrYgqnwGiXMg=="
+      "version": "4.0.12",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.12.tgz",
+      "integrity": "sha512-hgibXWrEDNBWgGiK18j/4lkS6ihTe9sxtV4Q1OQppb/0zzyPSzoFANBa5MfsG/zgsWklmNnhm0XACZOH/0HBiQ=="
     },
     "merge-stream": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "dependencies": {
     "debug": "^4.3.3",
-    "marked": "^2.1.0"
+    "marked": "^4.0.12"
   },
   "devDependencies": {
     "assert-dir-equal": "^1.1.0",


### PR DESCRIPTION
I tested this on Node.js 8 and Node.js 16 and the tests passed for both.